### PR TITLE
Add auto-reconnect when connection is suddenly lost

### DIFF
--- a/client.gd
+++ b/client.gd
@@ -20,14 +20,20 @@ enum SocketIOPacketType {
 	BINARY_ACK = 6,
 }
 
+enum ConnectionState {
+	DISCONNECTED,
+	CONNECTED,
+	RECONNECTING,
+}
+
 var _url: String
 var _client: WebSocketPeer = WebSocketPeer.new()
 var _sid: String
 var _pingTimeout: int = 0
 var _pingInterval: int = 0
-var _connected: bool = false
-var _reconnecting: bool = false
 var _auth: Variant = null
+var _connection_state: ConnectionState = ConnectionState.DISCONNECTED
+var _reconnect_timer: Timer = null
 
 # triggered when engine.io connection is established
 signal on_engine_connected(sid: String)
@@ -84,7 +90,6 @@ func _process(_delta):
 			# TODO: handle binary data?
 
 	elif state == WebSocketPeer.STATE_CLOSED:
-		_connected = false
 		set_process(false)
 
 		var code = _client.get_close_code()
@@ -93,29 +98,33 @@ func _process(_delta):
 		if code == -1:
 			# -1 is not-clean disconnect (i.e. Service shut down)
 			# we should try to reconnect
-			_reconnecting = true
 
-			var timer := Timer.new()
-			timer.wait_time = 1.0
-			timer.timeout.connect(_on_reconnect_timer_timeout.bind(timer))
-			timer.autostart = true
-			add_child(timer)
+			_connection_state = ConnectionState.RECONNECTING
+
+			_reconnect_timer = Timer.new()
+			_reconnect_timer.wait_time = 1.0
+			_reconnect_timer.timeout.connect(_on_reconnect_timer_timeout)
+			_reconnect_timer.autostart = true
+			add_child(_reconnect_timer)
 
 			on_connection_lost.emit()
 		else:
+			_connection_state = ConnectionState.DISCONNECTED
 			on_engine_disconnected.emit(code, reason)
 
-func _on_reconnect_timer_timeout(timer: Timer):
+func _on_reconnect_timer_timeout():
 	_client.poll()
 	var state = _client.get_ready_state()
 	if state == WebSocketPeer.STATE_CLOSED:
 		_client.connect_to_url(_url)
 	else:
 		set_process(true)
-		timer.queue_free()
+		_reconnect_timer.queue_free()
 
 func _exit_tree():
-	_engineio_send_packet(EngineIOPacketType.close)
+	if _connection_state == ConnectionState.CONNECTED:
+		_engineio_send_packet(EngineIOPacketType.close)
+
 	_client.close()
 
 func _engineio_decode_packet(packet: String):
@@ -130,7 +139,6 @@ func _engineio_decode_packet(packet: String):
 			_pingTimeout = int(json.data["pingTimeout"])
 			_pingInterval = int(json.data["pingInterval"])
 			on_engine_connected.emit(_sid)
-			_connected = true
 
 		EngineIOPacketType.ping:
 			_engineio_send_packet(EngineIOPacketType.pong)
@@ -178,17 +186,21 @@ func _socketio_parse_packet(payload: String):
 
 	match packetType:
 		SocketIOPacketType.CONNECT:
-			if _reconnecting:
-				_reconnecting = false
+			if _connection_state == ConnectionState.RECONNECTING:
+				_connection_state = ConnectionState.CONNECTED
 				on_reconnected.emit(data, name_space, false)
 			else:
+				_connection_state = ConnectionState.CONNECTED
 				on_connect.emit(data, name_space, false)
+
 		SocketIOPacketType.CONNECT_ERROR:
-			if _reconnecting:
-				_reconnecting = false
+			if _connection_state == ConnectionState.RECONNECTING:
+				_connection_state = ConnectionState.CONNECTED
 				on_reconnected.emit(data, name_space, true)
 			else:
+				_connection_state = ConnectionState.CONNECTED
 				on_connect.emit(data, name_space, true)
+
 		SocketIOPacketType.EVENT:
 			if typeof(data) != TYPE_ARRAY:
 				push_error("Invalid socketio event format!")
@@ -218,7 +230,10 @@ func socketio_connect(name_space: String="/"):
 
 # disconnect from socket.io server by namespace
 func socketio_disconnect(name_space: String="/"):
-	_socketio_send_packet(SocketIOPacketType.DISCONNECT, name_space)
+	if _connection_state == ConnectionState.CONNECTED:
+		# We should ONLY send disconnect packet when we're connected
+		_socketio_send_packet(SocketIOPacketType.DISCONNECT, name_space)
+
 	on_disconnect.emit(name_space)
 
 # send event to socket.io server by namespace
@@ -227,3 +242,6 @@ func socketio_send(event_name: String, payload: Variant=null, name_space: String
 		_socketio_send_packet(SocketIOPacketType.EVENT, name_space, [event_name])
 	else:
 		_socketio_send_packet(SocketIOPacketType.EVENT, name_space, [event_name, payload])
+
+func get_connection_state() -> ConnectionState:
+	return _connection_state


### PR DESCRIPTION
Similar to other Socket.io client libraries (i.e. [python-socketio](https://python-socketio.readthedocs.io/en/stable/)), I added auto reconnecting when the connection is lost in not-clean way (i.e. due to service shut down).

I coded it because I need stable connection for my application, and I think it's worth to have such reconnecting in the client code itself (to not need to bother handling edge cases in the application code itself)

I added 2 extra signals: `on_connection_lost` and `on_reconnected` to be able to display messages like "We're trying to reconnect you...", etc., and to stop pushing messages, until the connection is retrieved.

This PR also replaces `_connected` flag (which was unused) with more flexible `_connection_state`, with `RECONNECTING` being one of the possible states.

As for now, when the client successfully reconnects, it does NOT connect to any specific Socket.io namespace. Instead, it makes the same `on_engine_connected` signal being emitted, and one must again manually call `socketio_connect` to join specific namespaces. I think it would be great idea to automate also that bit, but I didn't want to mess up to much in this very PR.

Minimal script to test/demo these changes:
```GDScript
extends Node

var client: SocketIOClient

func _ready():
	client = SocketIOClient.new("ws://0.0.0.0:8081/socket.io")
	
	client.on_engine_connected.connect(on_socket_ready)
	client.on_connect.connect(on_socket_connect)
	client.on_connection_lost.connect(on_connection_lost)
	client.on_reconnected.connect(on_reconnected)
	
	add_child(client)

func on_socket_ready(_sid: String):
	print("Socket ready. Connecting to namespace...")
	# Connect (or re-connect) to each namespace
	client.socketio_connect()

func on_socket_connect(_payload: Variant, _name_space, _error: bool):
	print("Socket connected!")

func on_connection_lost():
	print("Connection lost. Trying to reconnect. Hold tight!")

func on_reconnected(_payload: Variant, _name_space, _error: bool):
	print("Connection retrieved!")
```