### PR TITLE
Implement socketio_send_binary and socketio_send_multiple_binary methods

### DIFF
--- a/client.gd
+++ b/client.gd
@@ -243,5 +243,17 @@ func socketio_send(event_name: String, payload: Variant=null, name_space: String
 	else:
 		_socketio_send_packet(SocketIOPacketType.EVENT, name_space, [event_name, payload])
 
+# send binary data to socket.io server by namespace
+func socketio_send_binary(event_name: String, payload: PackedByteArray, name_space: String = "/"):
+	socketio_send_multiple_binary(event_name, [payload], name_space)
+
+# send multiple binary data to socket.io server by namespace
+func socketio_send_multiple_binary(event_name: String, payloads: Array[PackedByteArray], name_space: String = "/"):
+	var data = [event_name]
+	for i in range(payloads.size()):
+		data.append({"_placeholder": true, "num": i})
+
+	_socketio_send_packet(SocketIOPacketType.BINARY_EVENT, name_space, data, payloads)
+
 func get_connection_state() -> ConnectionState:
 	return _connection_state

--- a/example.gd
+++ b/example.gd
@@ -40,3 +40,9 @@ func on_socket_event(event_name: String, payload: Variant, _name_space):
 	print("Received ", event_name, " ", payload)
 	# respond hello world
 	client.socketio_send("hello", "world")
+
+	var binary_content: PackedByteArray = "file content or other".to_utf8_buffer()
+	client.socketio_send_binary("upload", binary_content)
+
+	# Multiple
+	client.socketio_send_multiple_binary("upload", [binary_content, binary_content])


### PR DESCRIPTION
These methods allow sending files or other binary content.

Makes use of `binaryData` argument from `_socketio_send_packet` method, which up to this point was never filled